### PR TITLE
added authentication capability with api token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@ services:
     restart: on-failure:0
     environment:
       QUERY_DEFAULTS_LIMIT: 25
-      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+        # AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      AUTHENTICATION_APIKEY_ENABLED: 'true'
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: 'test-key'
+      AUTHENTICATION_APIKEY_USERS: 'test'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       DEFAULT_VECTORIZER_MODULE: 'none'
       ENABLE_MODULES: 'backup-filesystem'

--- a/weaviate-community/src/backups.rs
+++ b/weaviate-community/src/backups.rs
@@ -14,6 +14,7 @@ use crate::collections::error::BackupError;
 
 /// All backup related endpoints and functionality described in
 /// [Weaviate meta API documentation](https://weaviate.io/developers/weaviate/api/rest/backups)
+#[derive(Debug)]
 pub struct Backups {
     endpoint: Url,
     client: Arc<reqwest::Client>,
@@ -35,7 +36,7 @@ impl Backups {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let my_request = BackupCreateRequest { 
     ///         id: "doc-test-backup".into(),
     ///         include: None, 
@@ -87,7 +88,7 @@ impl Backups {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let res = client.backups.get_backup_status(
     ///         &BackupBackends::FILESYSTEM,
     ///         "doc-test-backup",
@@ -121,7 +122,7 @@ impl Backups {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let my_request = BackupRestoreRequest { 
     ///         include: None, 
     ///         exclude: None
@@ -207,7 +208,7 @@ mod tests {
                 BackupRestoreRequest
             }, 
             objects::Object
-        }
+        }, AuthApiKey
     };
 
     fn test_backup_create_req() -> BackupCreateRequest {
@@ -235,7 +236,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_backup() {
         let obj = test_object("BackupTest");
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let _ = client.objects.create(&obj, None).await;
 
         // create

--- a/weaviate-community/src/batch.rs
+++ b/weaviate-community/src/batch.rs
@@ -8,6 +8,7 @@ use crate::collections::{
     objects::{ConsistencyLevel, Objects},
 };
 
+#[derive(Debug)]
 pub struct Batch {
     endpoint: Url,
     client: Arc<reqwest::Client>,
@@ -81,7 +82,7 @@ mod tests {
             batch::{BatchDeleteRequest, MatchConfig},
             objects::{Object, Objects},
         },
-        WeaviateClient,
+        WeaviateClient, AuthApiKey,
     };
     use uuid::Uuid;
 
@@ -139,7 +140,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_objects_batch_add_and_delete() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid_one = Uuid::new_v4();
         let uuid_two = Uuid::new_v4();
         let objects = test_objects("TestObjectsBatchAdd", &uuid_one, &uuid_two);

--- a/weaviate-community/src/classification.rs
+++ b/weaviate-community/src/classification.rs
@@ -2,6 +2,7 @@ use reqwest::Url;
 use std::error::Error;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct _Classification {
     _endpoint: Url,
     _client: Arc<reqwest::Client>,

--- a/weaviate-community/src/collections/auth.rs
+++ b/weaviate-community/src/collections/auth.rs
@@ -1,0 +1,22 @@
+use reqwest::header::HeaderValue;
+
+/// The `AuthApiKey` can be used to attach a bearer token to a `WeaviateClient`.
+#[derive(Debug)]
+pub struct AuthApiKey {
+    pub api_key: String,
+}
+
+impl AuthApiKey {
+    /// Construct a new `AuthApiKey`.
+    pub fn new(api_key: &str) -> Self {
+        AuthApiKey { api_key: api_key.into() }
+    }
+
+    /// Retrieve the `reqwest::header::HeaderValue` for an Authorization header.
+    pub fn get_header_value(&self) -> HeaderValue {
+        let mut bearer = String::from("Bearer ");
+        bearer.push_str(&self.api_key);
+        let header_val = HeaderValue::from_str(&bearer).unwrap();
+        return header_val
+    }
+}

--- a/weaviate-community/src/collections/mod.rs
+++ b/weaviate-community/src/collections/mod.rs
@@ -1,7 +1,8 @@
+pub mod auth;
+pub mod backups;
 pub mod batch;
 pub mod error;
+pub mod meta;
 pub mod objects;
 pub mod oidc;
 pub mod schema;
-pub mod meta;
-pub mod backups;

--- a/weaviate-community/src/collections/objects.rs
+++ b/weaviate-community/src/collections/objects.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 ///     };
 ///
 ///     // Insert the new object into the database
-///     let client = WeaviateClient::new("http://localhost:8080").unwrap();
+///     let client = WeaviateClient::new("http://localhost:8080", None).unwrap();
 ///     let res = client.objects.create(&new_class, Some(ConsistencyLevel::ALL)).await;
 /// }
 /// ```

--- a/weaviate-community/src/meta.rs
+++ b/weaviate-community/src/meta.rs
@@ -6,6 +6,7 @@ use crate::collections::meta::Metadata;
 
 /// All meta related endpoints and functionality described in
 /// [Weaviate meta API documentation](https://weaviate.io/developers/weaviate/api/rest/meta)
+#[derive(Debug)]
 pub struct Meta {
     /// The full URL to the Meta endpoint
     endpoint: Url,
@@ -32,12 +33,12 @@ impl Meta {
     /// If the client is unable to execute get, an Err result is returned.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// use weaviate_community::WeaviateClient;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let res = client.meta.get_meta().await?;
     ///     println!("{:#?}", res);
     ///     Ok(())
@@ -52,12 +53,13 @@ impl Meta {
 
 #[cfg(test)]
 mod tests {
-    use crate::WeaviateClient;
+    use crate::{WeaviateClient, AuthApiKey};
 
     /// Test the get_meta endpoint
     #[tokio::test]
     async fn test_get_meta() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let res = client.meta.get_meta().await;
         assert_eq!(
             "http://[::]:8080",

--- a/weaviate-community/src/modules.rs
+++ b/weaviate-community/src/modules.rs
@@ -2,6 +2,7 @@ use reqwest::Url;
 use std::error::Error;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct _Modules {
     _endpoint: Url,
     _client: Arc<reqwest::Client>,

--- a/weaviate-community/src/nodes.rs
+++ b/weaviate-community/src/nodes.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 /// All nodes related endpoints and functionality described in
 /// [Weaviate nodes API documentation](https://weaviate.io/developers/weaviate/api/rest/nodes)
+#[derive(Debug)]
 pub struct Nodes {
     /// The full URL to the Meta endpoint
     endpoint: Url,
@@ -47,10 +48,11 @@ impl Nodes {
     /// use weaviate_community::WeaviateClient;
     ///
     /// #[tokio::main]
-    /// async fn main() {
-    ///     let client = WeaviateClient::new("http://localhost:8080").unwrap();
-    ///     let res = client.nodes.get_nodes_status().await;
-    ///     println!("{:#?}", res.unwrap().json::<serde_json::Value>().await);
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>>{
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
+    ///     let res = client.nodes.get_nodes_status().await?;
+    ///     println!("{:#?}", res.json::<serde_json::Value>().await);
+    ///     Ok(())
     /// }
     /// ```
     pub async fn get_nodes_status(&self) -> Result<Response, Box<dyn Error>> {
@@ -61,11 +63,12 @@ impl Nodes {
 
 #[cfg(test)]
 mod tests {
-    use crate::WeaviateClient;
+    use crate::{WeaviateClient, AuthApiKey};
 
     #[tokio::test]
     async fn test_get_nodes_status() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let res = client.nodes.get_nodes_status().await;
         let nodes = res.unwrap().json::<serde_json::Value>().await.unwrap();
         assert_eq!("weaviate1", nodes["nodes"][0]["name"]);

--- a/weaviate-community/src/objects.rs
+++ b/weaviate-community/src/objects.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 /// All objects endpoints and functionality described in
 /// [Weaviate objects API documentation](https://weaviate.io/developers/weaviate/api/rest/objects)
 ///
+#[derive(Debug)]
 pub struct Objects {
     endpoint: Url,
     client: Arc<reqwest::Client>,
@@ -272,7 +273,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::collections::objects::{ConsistencyLevel, Object};
-    use crate::WeaviateClient;
+    use crate::{WeaviateClient, AuthApiKey};
 
     fn test_object(class_name: &str, id: Option<Uuid>) -> Object {
         let properties = serde_json::json!({
@@ -293,7 +294,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_objects() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd303").unwrap();
         let object = test_object("TestListObject", Some(uuid.clone()));
         let res = client
@@ -328,7 +330,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_object() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd202").unwrap();
         let object = test_object("TestGetObject", Some(uuid.clone()));
         let res = client
@@ -356,7 +359,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_object() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd967").unwrap();
         let object = test_object("TestDeleteObject", Some(uuid.clone()));
         let res = client
@@ -373,7 +377,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_exists_object() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd555").unwrap();
         let object = test_object("TestExistsObject", Some(uuid.clone()));
         let res = client
@@ -416,7 +421,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_object() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd178").unwrap();
         let object = test_object("TestCreateObject", Some(uuid.clone()));
         let res = client
@@ -438,7 +444,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_replace_object() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd666").unwrap();
         let object = test_object("TestReplaceObject", Some(uuid.clone()));
         let res = client
@@ -488,7 +495,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_object() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let uuid = Uuid::from_str("ee22d1b8-3b95-4e94-96d5-9a2b60fbd444").unwrap();
         let object = test_object("TestUpdateObject", Some(uuid.clone()));
         let res = client

--- a/weaviate-community/src/oidc.rs
+++ b/weaviate-community/src/oidc.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::collections::error::NotConfiguredError;
 use crate::collections::oidc::OidcResponse;
 
+#[derive(Debug)]
 pub struct Oidc {
     endpoint: Url,
     client: Arc<reqwest::Client>,
@@ -48,11 +49,12 @@ impl Oidc {
 
 #[cfg(test)]
 mod tests {
-    use crate::WeaviateClient;
+    use crate::{WeaviateClient, AuthApiKey};
 
     #[tokio::test]
     async fn test_get_open_id_configuration() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let _res = client.oidc.get_open_id_configuration().await;
     }
 }

--- a/weaviate-community/src/schema.rs
+++ b/weaviate-community/src/schema.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 /// All schema related endpoints and functionality described in
 /// [Weaviate schema API documentation](https://weaviate.io/developers/weaviate/api/rest/schema)
+#[derive(Debug)]
 pub struct Schema {
     endpoint: Url,
     client: Arc<reqwest::Client>,
@@ -24,12 +25,12 @@ impl Schema {
     /// Facilitates the retrieval of the configuration for a single class in the schema.
     ///
     /// GET /v1/schema/{class_name}
-    /// ```
+    /// ```no_run
     /// use weaviate_community::WeaviateClient;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let response = client.schema.get_class("Library").await;
     ///     assert!(response.is_err());
     ///     Ok(())
@@ -54,12 +55,12 @@ impl Schema {
     /// Facilitates the retrieval of the full Weaviate schema.
     ///
     /// GET /v1/schema
-    /// ```
+    /// ```no_run
     /// use weaviate_community::WeaviateClient;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let schema = client.schema.get().await?;
     ///     println!("{:#?}", &schema);
     ///     Ok(())
@@ -89,7 +90,7 @@ impl Schema {
     /// [Weaviate auto-schema documentation](https://weaviate.io/developers/weaviate/config-refs/schema#auto-schema)
     ///
     /// POST /v1/schema
-    /// ```
+    /// ```no_run
     /// use weaviate_community::WeaviateClient;
     /// use weaviate_community::collections::schema::Class;
     ///
@@ -109,7 +110,7 @@ impl Schema {
     ///         replication_config: None,
     ///     };
     ///
-    ///     let client = WeaviateClient::new("http://localhost:8080")?;
+    ///     let client = WeaviateClient::new("http://localhost:8080", None)?;
     ///     let class = client.schema.create_class(&class).await?;
     ///     println!("{:#?}", &class);
     ///
@@ -140,12 +141,12 @@ impl Schema {
     /// Remove a class (and all data in the instances) from the schema.
     ///
     /// DELETE v1/schema/{class_name}
-    /// ```
+    /// ```no_run
     /// use weaviate_community::WeaviateClient;
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let client = WeaviateClient::new("http://localhost:8080").unwrap();
+    ///     let client = WeaviateClient::new("http://localhost:8080", None).unwrap();
     ///     let response = client.schema.delete("Library").await;
     /// }
     /// ```
@@ -357,7 +358,7 @@ mod tests {
         ActivityStatus, Class, ClassBuilder, MultiTenancyConfig, Property, ShardStatus, Tenant,
         Tenants,
     };
-    use crate::WeaviateClient;
+    use crate::{WeaviateClient, AuthApiKey, WeaviateClientBuilder};
 
     /// Helper function for generating a testing class
     fn test_class(class_name: &str, enabled: bool) -> Class {
@@ -400,7 +401,8 @@ mod tests {
     async fn test_create_single_class() {
         // Insert the class and get it from the schema
         let class = test_class("CreateSingle", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(&result.is_ok());
         assert_eq!(&result.unwrap().class, "CreateSingle");
@@ -421,7 +423,8 @@ mod tests {
     async fn test_get_single_class_ok() {
         // Insert, to make sure it exists.
         let class = test_class("GetSingleClass", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 
@@ -437,7 +440,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_single_class_err() {
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.get_class("DOESNOTEXIST").await;
         assert!(result.is_err());
     }
@@ -446,7 +450,8 @@ mod tests {
     async fn test_get_all_classes() {
         // Insert, to make sure it exists.
         let class = test_class("GetAllClasses", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 
@@ -465,7 +470,8 @@ mod tests {
     async fn test_update_single_class() {
         // Insert, to make sure it exists.
         let mut class = test_class("UpdateSingle", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 
@@ -483,7 +489,8 @@ mod tests {
     async fn test_add_property() {
         // Insert, to make sure it exists.
         let class = test_class("AddProperty", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 
@@ -510,7 +517,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_shards() {
         let class = test_class("GetShards", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 
@@ -525,7 +533,8 @@ mod tests {
     #[tokio::test]
     async fn test_update_shard_status() {
         let class = test_class("UpdateShards", false);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::new("http://localhost:8080", Some(auth)).unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 
@@ -561,7 +570,9 @@ mod tests {
     #[tokio::test]
     async fn test_list_tenants() {
         let class = test_class("ListTenants", true);
-        let client = WeaviateClient::new("http://localhost:8080").unwrap();
+        let auth = AuthApiKey::new("test-key");
+        let client = WeaviateClient::builder("http://localhost:8080").auth_secret(auth)
+            .build().unwrap();
         let result = client.schema.create_class(&class).await;
         assert!(result.is_ok());
 


### PR DESCRIPTION
WeaviateClient now uses builder pattern - it is possible to create with and without the auth token.

Auth token can be added to the client at creation time only. To update a token, a new client needs to be created at present.