### PR TITLE
Collections camelCase fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [circleci-url]: https://app.circleci.com/pipelines/github/Sam-Pewton/weaviate-community.rust
 [github-url]: https://github.com/Sam-Pewton/weaviate-community.rust
 [mit-url]: https://opensource.org/license/mit/
-[rsdocs-url]: https://docs.rs/weaviate-community/0.2.1/weaviate_community/
+[rsdocs-url]: https://docs.rs/weaviate-community/0.2.2/weaviate_community/
 [weaviate-url]: https://weaviate.io/developers/weaviate
 
 Community client for handling Weaviate vector database transactions written in Rust, for Rust.
@@ -27,7 +27,7 @@ cargo add weaviate-community
 
 or add the following to your `Cargo.toml` file
 ```text
-weaviate-community = "0.2.1"
+weaviate-community = "0.2.2"
 ```
 
 # Documentation

--- a/weaviate-community/Cargo.toml
+++ b/weaviate-community/Cargo.toml
@@ -2,7 +2,7 @@
 name = "weaviate-community"
 # Update the README version number when updating crates.io
 # Create a new git tag
-version = "0.2.1"
+version = "0.2.2"
 repository = "https://github.com/Sam-Pewton/weaviate-community.rust"
 authors = ["Sam Pewton <s.pewton@outlook.com>"]
 readme = "README.md"

--- a/weaviate-community/src/collections/batch.rs
+++ b/weaviate-community/src/collections/batch.rs
@@ -312,6 +312,7 @@ pub struct BatchAddObjects(Vec<BatchAddObject>);
 /// There should be no need to manually create this object, it forms part of the response from the
 /// batch add endpoint.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct BatchAddObject {
     pub class: String,
     pub properties: serde_json::Value,

--- a/weaviate-community/src/collections/modules.rs
+++ b/weaviate-community/src/collections/modules.rs
@@ -18,6 +18,7 @@ pub struct ContextionaryConcept {
 /// This shouldn't be something you create yourself, as it is returned by the appropriate
 /// endpoint when deserialized.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct IndividualWords {
     pub info: Option<ContextionaryConceptInfo>,
     pub present: Option<bool>,
@@ -56,6 +57,7 @@ pub struct IndividualWord {
 /// This shouldn't be something you create yourself, as it is returned by the appropriate
 /// endpoint when deserialized.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ConcatenatedWords {
     concatenated_word: ConcatenatedWord,
 }
@@ -66,6 +68,7 @@ pub struct ConcatenatedWords {
 /// This shouldn't be something you create yourself, as it is returned by the appropriate
 /// endpoint when deserialized.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ConcatenatedWord {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]

--- a/weaviate-community/src/collections/objects.rs
+++ b/weaviate-community/src/collections/objects.rs
@@ -28,6 +28,7 @@ impl MultiObjects {
 
 /// Object struct used for creating a new Object.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Object {
     pub class: String,
     pub properties: serde_json::Value,


### PR DESCRIPTION
There were some missing camelCase conversions causing data to not propagate from the request responses properly (for example, the unix creation/update timestamps).