### PR TITLE
fix failing tests (mockito needed to be async)

### DIFF
--- a/weaviate-community/src/batch.rs
+++ b/weaviate-community/src/batch.rs
@@ -276,8 +276,8 @@ mod tests {
         WeaviateClient,
     };
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
@@ -381,7 +381,7 @@ mod tests {
         .unwrap()
     }
 
-    fn mock_post(
+    async fn mock_post(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -395,7 +395,7 @@ mod tests {
             .create()
     }
 
-    fn mock_delete(
+    async fn mock_delete(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -413,8 +413,8 @@ mod tests {
     async fn test_objects_batch_add_ok() {
         let objects = test_create_objects();
         let res_str = test_batch_add_object_response();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/batch/objects", 200, &res_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/batch/objects", 200, &res_str).await;
         let res = client.batch.objects_batch_add(objects, None, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -423,8 +423,8 @@ mod tests {
     #[tokio::test]
     async fn test_objects_batch_add_err() {
         let objects = test_create_objects();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/batch/objects", 404, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/batch/objects", 404, "").await;
         let res = client.batch.objects_batch_add(objects, None, None).await;
         mock.assert();
         assert!(res.is_err());
@@ -435,8 +435,8 @@ mod tests {
         let req = test_delete_objects();
         let out = test_delete_response();
         let res_str = serde_json::to_string(&out).unwrap();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_delete(&mut mock_server, "/v1/batch/objects", 200, &res_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_delete(&mut mock_server, "/v1/batch/objects", 200, &res_str).await;
         let res = client.batch.objects_batch_delete(req, None, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -445,8 +445,8 @@ mod tests {
     #[tokio::test]
     async fn test_objects_batch_delete_err() {
         let req = test_delete_objects();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_delete(&mut mock_server, "/v1/batch/objects", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_delete(&mut mock_server, "/v1/batch/objects", 401, "").await;
         let res = client.batch.objects_batch_delete(req, None, None).await;
         mock.assert();
         assert!(res.is_err());
@@ -456,8 +456,8 @@ mod tests {
     async fn test_references_batch_add_ok() {
         let refs = test_references();
         let res_str = test_add_references_response();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/batch/references", 200, &res_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/batch/references", 200, &res_str).await;
         let res = client.batch.references_batch_add(refs, None, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -466,8 +466,8 @@ mod tests {
     #[tokio::test]
     async fn test_references_batch_add_err() {
         let refs = test_references();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/batch/references", 500, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/batch/references", 500, "").await;
         let res = client.batch.references_batch_add(refs, None, None).await;
         mock.assert();
         assert!(res.is_err());

--- a/weaviate-community/src/classification.rs
+++ b/weaviate-community/src/classification.rs
@@ -143,8 +143,8 @@ mod tests {
         collections::classification::{ClassificationRequest, ClassificationType}
     };
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
@@ -166,7 +166,7 @@ mod tests {
             .build()
     }
 
-    fn mock_post(
+    async fn mock_post(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -180,7 +180,7 @@ mod tests {
             .create()
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -200,8 +200,8 @@ mod tests {
     #[tokio::test]
     async fn test_classification_schedule_err() {
         let req = test_classification_req();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/classifications/", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/classifications/", 401, "").await;
         let res = client.classification.schedule(req).await;
         mock.assert();
         assert!(res.is_err());
@@ -215,8 +215,8 @@ mod tests {
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/classifications/");
         url.push_str(&uuid.to_string());
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, &url, 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, &url, 401, "").await;
         let res = client.classification.get(uuid).await;
         mock.assert();
         assert!(res.is_err());

--- a/weaviate-community/src/lib.rs
+++ b/weaviate-community/src/lib.rs
@@ -331,15 +331,15 @@ impl WeaviateClientBuilder {
 mod tests {
     use super::*;
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
         (mock_server, client)
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -355,8 +355,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_ready_ok() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/.well-known/ready", 200, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/.well-known/ready", 200, "").await;
         let res = client.is_ready().await;
         mock.assert();
         assert!(res.is_ok());
@@ -364,8 +364,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_ready_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/.well-known/ready", 503, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/.well-known/ready", 503, "").await;
         let res = client.is_ready().await;
         mock.assert();
         assert!(res.is_ok());
@@ -374,8 +374,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_live_ok() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/.well-known/live", 200, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/.well-known/live", 200, "").await;
         let res = client.is_live().await;
         mock.assert();
         assert!(res.is_ok());
@@ -383,8 +383,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_live_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/.well-known/live", 404, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/.well-known/live", 404, "").await;
         let res = client.is_live().await;
         mock.assert();
         assert!(res.is_ok());

--- a/weaviate-community/src/meta.rs
+++ b/weaviate-community/src/meta.rs
@@ -55,8 +55,8 @@ impl Meta {
 mod tests {
     use crate::{collections::meta::Metadata, WeaviateClient};
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
@@ -78,7 +78,7 @@ mod tests {
         data
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -94,10 +94,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_meta_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let metadata = test_metadata();
         let metadata_str = serde_json::to_string(&metadata).unwrap();
-        let mock = mock_get(&mut mock_server, "/v1/meta/", 200, &metadata_str);
+        let mock = mock_get(&mut mock_server, "/v1/meta/", 200, &metadata_str).await;
         let res = client.meta.get_meta().await;
         mock.assert();
         assert!(res.is_ok());
@@ -106,8 +106,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_meta_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/meta/", 404, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/meta/", 404, "").await;
         let res = client.meta.get_meta().await;
         mock.assert();
         assert!(res.is_err());

--- a/weaviate-community/src/modules.rs
+++ b/weaviate-community/src/modules.rs
@@ -133,8 +133,8 @@ mod tests {
         }
     };
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
@@ -154,7 +154,7 @@ mod tests {
         }).unwrap()
     }
 
-    fn mock_post(
+    async fn mock_post(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -168,7 +168,7 @@ mod tests {
             .create()
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -184,13 +184,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_concept_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_get(
             &mut mock_server,
             "/v1/modules/text2vec-contextionary/concepts/test",
             200,
             &get_mock_concept_response(),
-        );
+        ).await;
         let res = client.modules.contextionary_get_concept("test").await;
         mock.assert();
         assert!(res.is_ok());
@@ -198,13 +198,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_concept_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_get(
             &mut mock_server,
             "/v1/modules/text2vec-contextionary/concepts/test",
             401,
             "",
-        );
+        ).await;
         let res = client.modules.contextionary_get_concept("test").await;
         mock.assert();
         assert!(res.is_err());
@@ -214,13 +214,13 @@ mod tests {
     async fn test_extend_ok() {
         let ext = ContextionaryExtension::new("test", "test", 1.0);
         let ext_str = serde_json::to_string(&ext).unwrap();
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_post(
             &mut mock_server,
             "/v1/modules/text2vec-contextionary/extensions",
             200,
             &ext_str,
-        );
+        ).await;
         let res = client.modules.contextionary_extend(ext).await;
         mock.assert();
         assert!(res.is_ok());
@@ -228,13 +228,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_extend_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_post(
             &mut mock_server,
             "/v1/modules/text2vec-contextionary/extensions",
             401,
             "",
-        );
+        ).await;
         let res = client.modules.contextionary_extend(
             ContextionaryExtension::new("test", "test", 1.0)
         ).await;

--- a/weaviate-community/src/nodes.rs
+++ b/weaviate-community/src/nodes.rs
@@ -54,8 +54,8 @@ impl Nodes {
 mod tests {
     use crate::{collections::nodes::MultiNodes, WeaviateClient};
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
@@ -159,7 +159,7 @@ mod tests {
         nodes
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -175,10 +175,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_nodes_status_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let nodes = test_nodes();
         let nodes_str = serde_json::to_string(&nodes).unwrap();
-        let mock = mock_get(&mut mock_server, "/v1/nodes/", 200, &nodes_str);
+        let mock = mock_get(&mut mock_server, "/v1/nodes/", 200, &nodes_str).await;
         let res = client.nodes.get_nodes_status().await;
         mock.assert();
         assert!(res.is_ok());
@@ -187,8 +187,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_nodes_status_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/nodes/", 404, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/nodes/", 404, "").await;
         let res = client.nodes.get_nodes_status().await;
         mock.assert();
         assert!(res.is_err());

--- a/weaviate-community/src/objects.rs
+++ b/weaviate-community/src/objects.rs
@@ -758,15 +758,15 @@ mod tests {
         Reference::new("Test", uuid, "testProperty", "TestTwo", uuid_2)
     }
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
         (mock_server, client)
     }
 
-    fn mock_post(
+    async fn mock_post(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -780,7 +780,7 @@ mod tests {
             .create()
     }
 
-    fn mock_put(
+    async fn mock_put(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -794,7 +794,7 @@ mod tests {
             .create()
     }
 
-    fn mock_patch(
+    async fn mock_patch(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -808,7 +808,7 @@ mod tests {
             .create()
     }
 
-    fn mock_head(
+    async fn mock_head(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -822,7 +822,7 @@ mod tests {
             .create()
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -836,7 +836,7 @@ mod tests {
             .create()
     }
 
-    fn mock_delete(
+    async fn mock_delete(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -849,10 +849,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let objects = test_objects("Test");
         let objects_str = serde_json::to_string(&objects).unwrap();
-        let mock = mock_get(&mut mock_server, "/v1/objects/", 200, &objects_str);
+        let mock = mock_get(&mut mock_server, "/v1/objects/", 200, &objects_str).await;
         let res = client.objects.list(ObjectListParameters::new()).await;
         mock.assert();
         assert!(res.is_ok());
@@ -861,8 +861,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/objects/", 422, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/objects/", 422, "").await;
         let res = client.objects.list(ObjectListParameters::new()).await;
         mock.assert();
         assert!(res.is_err());
@@ -870,10 +870,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let object = test_object("Test");
         let object_str = serde_json::to_string(&object).unwrap();
-        let mock = mock_post(&mut mock_server, "/v1/objects/", 200, &object_str);
+        let mock = mock_post(&mut mock_server, "/v1/objects/", 200, &object_str).await;
         let res = client.objects.create(&object, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -882,9 +882,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let object = test_object("Test");
-        let mock = mock_post(&mut mock_server, "/v1/objects/", 422, "");
+        let mock = mock_post(&mut mock_server, "/v1/objects/", 422, "").await;
         let res = client.objects.create(&object, None).await;
         mock.assert();
         assert!(res.is_err());
@@ -892,13 +892,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let object = test_object("Test");
         let object_str = serde_json::to_string(&object).unwrap();
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_get(&mut mock_server, &url, 200, &object_str);
+        let mock = mock_get(&mut mock_server, &url, 200, &object_str).await;
         let res = client.objects.get("Test", &uuid, None, None, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -907,11 +907,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_get(&mut mock_server, &url, 422, "");
+        let mock = mock_get(&mut mock_server, &url, 422, "").await;
         let res = client.objects.get("Test", &uuid, None, None, None).await;
         mock.assert();
         assert!(res.is_err());
@@ -919,11 +919,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_exists_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_head(&mut mock_server, &url, 204, "");
+        let mock = mock_head(&mut mock_server, &url, 204, "").await;
         let res = client.objects.exists("Test", &uuid, None, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -932,11 +932,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_exists_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_head(&mut mock_server, &url, 422, "");
+        let mock = mock_head(&mut mock_server, &url, 422, "").await;
         let res = client.objects.exists("Test", &uuid, None, None).await;
         mock.assert();
         assert!(res.is_err());
@@ -944,11 +944,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_patch(&mut mock_server, &url, 204, "");
+        let mock = mock_patch(&mut mock_server, &url, 204, "").await;
         let res = client
             .objects
             .update(&serde_json::json![{}], "Test", &uuid, None)
@@ -959,11 +959,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_patch(&mut mock_server, &url, 422, "");
+        let mock = mock_patch(&mut mock_server, &url, 422, "").await;
         let res = client
             .objects
             .update(&serde_json::json![{}], "Test", &uuid, None)
@@ -974,13 +974,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_replace_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let object = test_object("Test");
         let object_str = serde_json::to_string(&object).unwrap();
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_put(&mut mock_server, &url, 200, &object_str);
+        let mock = mock_put(&mut mock_server, &url, 200, &object_str).await;
         let res = client
             .objects
             .replace(&serde_json::json![{}], "Test", &uuid, None)
@@ -991,11 +991,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_replace_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_put(&mut mock_server, &url, 422, "");
+        let mock = mock_put(&mut mock_server, &url, 422, "").await;
         let res = client
             .objects
             .replace(&serde_json::json![{}], "Test", &uuid, None)
@@ -1006,11 +1006,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_delete(&mut mock_server, &url, 204);
+        let mock = mock_delete(&mut mock_server, &url, 204).await;
         let res = client.objects.delete("Test", &uuid, None, None).await;
         mock.assert();
         assert!(res.is_ok());
@@ -1018,11 +1018,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
-        let mock = mock_delete(&mut mock_server, &url, 404);
+        let mock = mock_delete(&mut mock_server, &url, 404).await;
         let res = client.objects.delete("Test", &uuid, None, None).await;
         mock.assert();
         assert!(res.is_err());
@@ -1030,9 +1030,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
-        let mock = mock_post(&mut mock_server, "/v1/objects/validate", 200, "");
+        let mock = mock_post(&mut mock_server, "/v1/objects/validate", 200, "").await;
         let res = client
             .objects
             .validate("Test", &serde_json::json![{}], &uuid)
@@ -1043,9 +1043,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
-        let mock = mock_post(&mut mock_server, "/v1/objects/validate", 404, "");
+        let mock = mock_post(&mut mock_server, "/v1/objects/validate", 404, "").await;
         let res = client
             .objects
             .validate("Test", &serde_json::json![{}], &uuid)
@@ -1056,13 +1056,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_reference_add_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let uuid_2 = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
         url.push_str("/references/testProperty");
-        let mock = mock_post(&mut mock_server, &url, 200, "");
+        let mock = mock_post(&mut mock_server, &url, 200, "").await;
         let res = client
             .objects
             .reference_add(test_reference(&uuid, &uuid_2))
@@ -1074,13 +1074,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_reference_add_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let uuid_2 = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
         url.push_str("/references/testProperty");
-        let mock = mock_post(&mut mock_server, &url, 404, "");
+        let mock = mock_post(&mut mock_server, &url, 404, "").await;
         let res = client
             .objects
             .reference_add(test_reference(&uuid, &uuid_2))
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_reference_update_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let object = test_object("Test");
         let object_str = serde_json::to_string(&object).unwrap();
         let uuid = Uuid::new_v4();
@@ -1099,7 +1099,7 @@ mod tests {
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
         url.push_str("/references/testProperty");
-        let mock = mock_put(&mut mock_server, &url, 200, &object_str);
+        let mock = mock_put(&mut mock_server, &url, 200, &object_str).await;
         let res = client
             .objects
             .reference_update(
@@ -1118,13 +1118,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_reference_update_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let uuid_2 = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
         url.push_str("/references/testProperty");
-        let mock = mock_put(&mut mock_server, &url, 404, "");
+        let mock = mock_put(&mut mock_server, &url, 404, "").await;
         let res = client
             .objects
             .reference_update(
@@ -1143,13 +1143,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_reference_delete_ok() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let uuid_2 = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
         url.push_str("/references/testProperty");
-        let mock = mock_delete(&mut mock_server, &url, 204);
+        let mock = mock_delete(&mut mock_server, &url, 204).await;
         let res = client
             .objects
             .reference_delete(test_reference(&uuid, &uuid_2))
@@ -1161,13 +1161,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_reference_delete_err() {
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let uuid = Uuid::new_v4();
         let uuid_2 = Uuid::new_v4();
         let mut url = String::from("/v1/objects/Test/");
         url.push_str(&uuid.to_string());
         url.push_str("/references/testProperty");
-        let mock = mock_delete(&mut mock_server, &url, 404);
+        let mock = mock_delete(&mut mock_server, &url, 404).await;
         let res = client
             .objects
             .reference_delete(test_reference(&uuid, &uuid_2))

--- a/weaviate-community/src/schema.rs
+++ b/weaviate-community/src/schema.rs
@@ -387,15 +387,15 @@ mod tests {
         Shards::new(vec![Shard::new("1D3PBjtz9W7r", ShardStatus::READY)])
     }
 
-    fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
-        let mock_server = mockito::Server::new();
+    async fn get_test_harness() -> (mockito::ServerGuard, WeaviateClient) {
+        let mock_server = mockito::Server::new_async().await;
         let mut host = "http://".to_string();
         host.push_str(&mock_server.host_with_port());
         let client = WeaviateClient::builder(&host).build().unwrap();
         (mock_server, client)
     }
 
-    fn mock_post(
+    async fn mock_post(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -409,7 +409,7 @@ mod tests {
             .create()
     }
 
-    fn mock_put(
+    async fn mock_put(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -423,7 +423,7 @@ mod tests {
             .create()
     }
 
-    fn mock_get(
+    async fn mock_get(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -437,7 +437,7 @@ mod tests {
             .create()
     }
 
-    fn mock_delete(
+    async fn mock_delete(
         server: &mut mockito::ServerGuard,
         endpoint: &str,
         status_code: usize,
@@ -452,8 +452,8 @@ mod tests {
     async fn test_create_class_ok() {
         let class = test_class("UnitClass");
         let class_str = serde_json::to_string(&class).unwrap();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/schema/", 200, &class_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/schema/", 200, &class_str).await;
         let res = client.schema.create_class(&class).await;
         mock.assert();
         assert!(res.is_ok());
@@ -463,8 +463,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_class_err() {
         let class = test_class("UnitClass");
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/schema/", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/schema/", 401, "").await;
         let res = client.schema.create_class(&class).await;
         mock.assert();
         assert!(res.is_err());
@@ -474,8 +474,8 @@ mod tests {
     async fn test_get_all_classes_ok() {
         let classes = test_classes();
         let class_str = serde_json::to_string(&classes).unwrap();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/", 200, &class_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/", 200, &class_str).await;
         let res = client.schema.get().await;
         mock.assert();
         assert!(res.is_ok());
@@ -484,8 +484,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_all_classes_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/", 401, "").await;
         let class = client.schema.get().await;
         mock.assert();
         assert!(class.is_err());
@@ -495,8 +495,8 @@ mod tests {
     async fn test_get_single_class_ok() {
         let class = test_class("Test");
         let class_str = serde_json::to_string(&class).unwrap();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/Test", 200, &class_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/Test", 200, &class_str).await;
         let res = client.schema.get_class("Test").await;
         mock.assert();
         assert!(res.is_ok());
@@ -505,8 +505,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_single_class_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/Test", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/Test", 401, "").await;
         let class = client.schema.get_class("Test").await;
         mock.assert();
         assert!(class.is_err());
@@ -514,8 +514,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_delete_class_ok() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_delete(&mut mock_server, "/v1/schema/Test", 200);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_delete(&mut mock_server, "/v1/schema/Test", 200).await;
         let res = client.schema.delete("Test").await;
         mock.assert();
         assert!(res.is_ok());
@@ -524,8 +524,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_delete_class_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_delete(&mut mock_server, "/v1/schema/Test", 401);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_delete(&mut mock_server, "/v1/schema/Test", 401).await;
         let class = client.schema.delete("Test").await;
         mock.assert();
         assert!(class.is_err());
@@ -535,8 +535,8 @@ mod tests {
     async fn test_update_class_ok() {
         let class = test_class("Test");
         let class_str = serde_json::to_string(&class).unwrap();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_put(&mut mock_server, "/v1/schema/Test", 200, &class_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_put(&mut mock_server, "/v1/schema/Test", 200, &class_str).await;
         let res = client.schema.update(&class).await;
         mock.assert();
         assert!(res.is_ok());
@@ -546,8 +546,8 @@ mod tests {
     #[tokio::test]
     async fn test_update_class_err() {
         let class = test_class("Test");
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_put(&mut mock_server, "/v1/schema/Test", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_put(&mut mock_server, "/v1/schema/Test", 401, "").await;
         let res = client.schema.update(&class).await;
         mock.assert();
         assert!(res.is_err());
@@ -557,13 +557,13 @@ mod tests {
     async fn test_add_property_ok() {
         let property = test_property("Test");
         let property_str = serde_json::to_string(&property).unwrap();
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_post(
             &mut mock_server,
             "/v1/schema/TestClass/properties",
             200,
             &property_str,
-        );
+        ).await;
         let res = client.schema.add_property("TestClass", &property).await;
         mock.assert();
         assert!(res.is_ok());
@@ -573,8 +573,8 @@ mod tests {
     #[tokio::test]
     async fn test_add_property_err() {
         let property = test_property("Test");
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/schema/TestClass/properties", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/schema/TestClass/properties", 401, "").await;
         let res = client.schema.add_property("TestClass", &property).await;
         mock.assert();
         assert!(res.is_err());
@@ -584,8 +584,8 @@ mod tests {
     async fn test_get_shards_ok() {
         let shards = test_shards();
         let shards_str = serde_json::to_string(&shards.shards).unwrap();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/Test/shards", 200, &shards_str);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/Test/shards", 200, &shards_str).await;
         let res = client.schema.get_shards("Test").await;
         mock.assert();
         assert!(res.is_ok());
@@ -594,8 +594,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_shards_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/Test/shards", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/Test/shards", 401, "").await;
         let res = client.schema.get_shards("Test").await;
         mock.assert();
         assert!(res.is_err());
@@ -605,13 +605,13 @@ mod tests {
     async fn test_update_class_shard_ok() {
         let shard = test_shard();
         let shard_str = serde_json::to_string(&shard).unwrap();
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_put(
             &mut mock_server,
             "/v1/schema/Test/shards/abcd",
             200,
             &shard_str,
-        );
+        ).await;
         let res = client
             .schema
             .update_class_shard("Test", "abcd", ShardStatus::READONLY)
@@ -623,8 +623,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_class_shard_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_put(&mut mock_server, "/v1/schema/Test/shards/abcd", 401, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_put(&mut mock_server, "/v1/schema/Test/shards/abcd", 401, "").await;
         let res = client
             .schema
             .update_class_shard("Test", "abcd", ShardStatus::READONLY)
@@ -637,13 +637,13 @@ mod tests {
     async fn test_list_tenants_ok() {
         let tenants = test_tenants();
         let tenants_str = serde_json::to_string(&tenants.tenants).unwrap();
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_get(
             &mut mock_server,
             "/v1/schema/Test/tenants",
             200,
             &tenants_str,
-        );
+        ).await;
         let res = client.schema.list_tenants("Test").await;
         mock.assert();
         assert!(res.is_ok());
@@ -652,8 +652,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_tenants_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_get(&mut mock_server, "/v1/schema/Test/tenants", 422, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_get(&mut mock_server, "/v1/schema/Test/tenants", 422, "").await;
         let res = client.schema.list_tenants("Test").await;
         mock.assert();
         assert!(res.is_err());
@@ -663,13 +663,13 @@ mod tests {
     async fn test_add_tenants_ok() {
         let tenants = test_tenants();
         let tenants_str = serde_json::to_string(&tenants.tenants).unwrap();
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_post(
             &mut mock_server,
             "/v1/schema/Test/tenants",
             200,
             &tenants_str,
-        );
+        ).await;
         let res = client.schema.add_tenants("Test", &tenants).await;
         mock.assert();
         assert!(res.is_ok());
@@ -679,8 +679,8 @@ mod tests {
     #[tokio::test]
     async fn test_add_tenants_err() {
         let tenants = test_tenants();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_post(&mut mock_server, "/v1/schema/Test/tenants", 422, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_post(&mut mock_server, "/v1/schema/Test/tenants", 422, "").await;
         let res = client.schema.add_tenants("Test", &tenants).await;
         mock.assert();
         assert!(res.is_err());
@@ -688,8 +688,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_tenants_ok() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_delete(&mut mock_server, "/v1/schema/Test/tenants", 200);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_delete(&mut mock_server, "/v1/schema/Test/tenants", 200).await;
         let res = client
             .schema
             .remove_tenants("Test", &vec!["TestTenant"])
@@ -701,8 +701,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_tenants_err() {
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_delete(&mut mock_server, "/v1/schema/Test/tenants", 422);
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_delete(&mut mock_server, "/v1/schema/Test/tenants", 422).await;
         let res = client
             .schema
             .remove_tenants("Test", &vec!["TestTenant"])
@@ -715,13 +715,13 @@ mod tests {
     async fn test_update_tenants_ok() {
         let tenants = test_tenants();
         let tenants_str = serde_json::to_string(&tenants.tenants).unwrap();
-        let (mut mock_server, client) = get_test_harness();
+        let (mut mock_server, client) = get_test_harness().await;
         let mock = mock_put(
             &mut mock_server,
             "/v1/schema/Test/tenants",
             200,
             &tenants_str,
-        );
+        ).await;
         let res = client.schema.update_tenants("Test", &tenants).await;
         mock.assert();
         assert!(res.is_ok());
@@ -731,8 +731,8 @@ mod tests {
     #[tokio::test]
     async fn test_update_tenants_err() {
         let tenants = test_tenants();
-        let (mut mock_server, client) = get_test_harness();
-        let mock = mock_put(&mut mock_server, "/v1/schema/Test/tenants", 422, "");
+        let (mut mock_server, client) = get_test_harness().await;
+        let mock = mock_put(&mut mock_server, "/v1/schema/Test/tenants", 422, "").await;
         let res = client.schema.update_tenants("Test", &tenants).await;
         mock.assert();
         assert!(res.is_err());


### PR DESCRIPTION
At some point, tests have started to fail due to mockito trying to create a sync runtime inside an async runtime.

I needed to change to use async mockito server.